### PR TITLE
Delete only expired lines from chat when enabled.

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -28,5 +28,8 @@
   },
   "linux": {
     "icon": "build/icon.ico"
+  },
+  "extraMetadata": {
+    "main": "background.js"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-chat",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-chat",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ghost-chat",
       "version": "1.3.3",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-chat",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": false,
   "description": "Standalone twitch chat overlay",
   "author": {

--- a/src/renderer/pages/Chat.vue
+++ b/src/renderer/pages/Chat.vue
@@ -117,15 +117,6 @@ export default class Chat extends Vue {
     }
   }
 
-  addSystemMessage(message): void {
-    const state = {
-      color: '#FF0000',
-      username: 'SYSTEM',
-    };
-
-    this.addMessage(state, message, []);
-  }
-
   addMessage(userstate, message, badges): void {
     const newItem = {
       user: {

--- a/src/renderer/pages/Chat.vue
+++ b/src/renderer/pages/Chat.vue
@@ -118,7 +118,7 @@ export default class Chat extends Vue {
   }
 
   addMessage(userstate, message, badges): void {
-    const newItem = {
+    const newItem: IMessageResponse = {
       user: {
         color: userstate.color || '#8d41e6',
         name: userstate.username,


### PR DESCRIPTION
This is similar to https://github.com/Enubia/ghost-chat/pull/398 but instead of using multiple timers, this extracts the entire `this.interval` timer in the `Chat` page to be persistent if a message timeout is enabled.

When the timer sweeps the messages array it compares the timestamp the same way the global sweep worked, but instead of clearing the entire message list - it removes the expired messages in-place from `this.data`, then in a single operation resizes the list to trigger the existing rendering.

This also involved a minor refactor of the `.on('message', ..)` handler to a call of `addMessage()`, and a single-use timer to clear the `Waiting for messages...` prompt after 15 seconds, rather than waiting for the first message to do it. Though the original behavior is preserved.

This also seemingly fixes the ability to run `npm run electron:build` - which previously failed by attempting to load the wrong entrypoint.

**Version bumped to 1.3.4** 