### PR TITLE
feat: add arm64 builds

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -16,7 +16,10 @@ module.exports = {
     ],
     mac: {
         artifactName: '${productName}-${version}-mac.${ext}',
-        target: 'default',
+        target: {
+            target: 'default',
+            arch: ['x64', 'arm64'],
+        },
         publish: ['github'],
     },
     win: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The currently available `.dmg` only works for `x64` arch. This PR adds `arm64` support. We could build for `universal` arch which would include both, but the app size increases significantly.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
