### PR TITLE
fix(windows): recover from corrupted config and fix vanish mode transparency

### DIFF
--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -40,7 +40,7 @@ func Load(path string) (*Config, error) {
 	var raw map[string]json.RawMessage
 
 	if err = json.Unmarshal(bytes, &raw); err != nil {
-		return nil, err
+		return recoverCorrupted(path, bytes, err)
 	}
 
 	if _, hasV3Key := raw["savedWindowState"]; hasV3Key {
@@ -52,10 +52,21 @@ func Load(path string) (*Config, error) {
 	config := DefaultConfig()
 
 	if err = json.Unmarshal(bytes, &config); err != nil {
-		return nil, err
+		return recoverCorrupted(path, bytes, err)
 	}
 
 	return &config, nil
+}
+
+func recoverCorrupted(path string, bytes []byte, err error) (*Config, error) {
+	println("Warning: config file is corrupted, backing up and starting fresh:", err.Error())
+
+	_ = os.WriteFile(path+".corrupted", bytes, 0644)
+	_ = os.Remove(path)
+
+	defaultConfig := DefaultConfig()
+
+	return &defaultConfig, nil
 }
 
 func Save(config *Config, path string) error {
@@ -69,5 +80,31 @@ func Save(config *Config, path string) error {
 		return err
 	}
 
-	return os.WriteFile(path, bytes, 0644)
+	tempPath := path + ".tmp"
+
+	f, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		f.Close()
+
+		_ = os.Remove(tempPath)
+	}()
+
+	if _, err = f.Write(bytes); err != nil {
+		return err
+	}
+
+	if err = f.Sync(); err != nil {
+		return err
+	}
+
+	if err = f.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tempPath, path)
 }

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -61,7 +61,7 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 }
 
-func TestLoadReturnsErrorForInvalidJSON(t *testing.T) {
+func TestLoadRecoversFromInvalidJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	path := filepath.Join(tmpDir, "ghost-chat", "config.json")
@@ -70,17 +70,39 @@ func TestLoadReturnsErrorForInvalidJSON(t *testing.T) {
 		t.Fatal("Failed to create tmp dir", err)
 	}
 
-	if err := os.WriteFile(path, []byte("not json"), 0644); err != nil {
+	garbageBytes := []byte("not json")
+
+	if err := os.WriteFile(path, garbageBytes, 0644); err != nil {
 		t.Fatal("Failed to write garbage data", err)
 	}
 
 	config, err := Load(path)
 
-	if err == nil {
-		t.Error("Expected error for invalid JSON, got nil")
+	if err != nil {
+		t.Fatal("Expected nil error for invalid JSON, got", err)
 	}
 
-	if config != nil {
-		t.Error("Expected nil config, got", config)
+	if config == nil {
+		t.Fatal("Expected default config, got nil")
+	}
+
+	defaultConfig := DefaultConfig()
+
+	if config.General.Language != defaultConfig.General.Language {
+		t.Errorf("got %v, want %v", config.General.Language, defaultConfig.General.Language)
+	}
+
+	backupBytes, err := os.ReadFile(path + ".corrupted")
+
+	if err != nil {
+		t.Fatal("Expected corrupted backup file to exist, got", err)
+	}
+
+	if string(backupBytes) != string(garbageBytes) {
+		t.Errorf("got backup bytes %q, want %q", backupBytes, garbageBytes)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("Expected corrupted file at %s to be removed, but it still exists", path)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"embed"
 	"ghost-chat/internal/config"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
@@ -49,9 +52,20 @@ func main() {
 
 	initialW, initialH := sanitizeWindowSize(cfg.WindowState.Width, cfg.WindowState.Height)
 
+	var webviewUserDataPath string
+
+	if runtime.GOOS == "windows" {
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			webviewUserDataPath = filepath.Join(localAppData, "ghost-chat", "webview")
+		}
+	}
+
 	app := application.New(application.Options{
 		Name: "Ghost Chat",
 		Icon: appIcon,
+		Windows: application.WindowsOptions{
+			WebviewUserDataPath: webviewUserDataPath,
+		},
 		ShouldQuit: func() bool {
 			svc.SaveWindowState()
 			return true
@@ -68,13 +82,17 @@ func main() {
 	})
 
 	win := app.Window.NewWithOptions(application.WebviewWindowOptions{
-		Title:          "ghost-chat",
-		Width:          initialW,
-		Height:         initialH,
-		Hidden:         true,
-		Frameless:      true,
-		AlwaysOnTop:    true,
-		BackgroundType: application.BackgroundTypeTransparent,
+		Title:            "ghost-chat",
+		Width:            initialW,
+		Height:           initialH,
+		Hidden:           true,
+		Frameless:        true,
+		AlwaysOnTop:      true,
+		BackgroundType:   application.BackgroundTypeTransparent,
+		BackgroundColour: application.NewRGBA(0, 0, 0, 0),
+		Windows: application.WindowsWindow{
+			DisableFramelessWindowDecorations: true,
+		},
 		Mac: application.MacWindow{
 			Backdrop: application.MacBackdropTransparent,
 		},


### PR DESCRIPTION
Ports the Windows fixes from @BigSquidAUS's fork (BigSquidAUS/ghost-chat@f824f3ce) — thanks Ben for the excellent diagnosis.

## Post-reboot startup crash

A reboot or power loss could interrupt the config save in `ShouldQuit`, leaving `config.json` corrupted or empty. On the next launch `Load` returned an error and `main` exited before creating a window — invisible under `-H windowsgui`, so the app appeared to never start until the user deleted the AppData folder.

- `Save` now writes to `config.json.tmp`, syncs it to physical disk, and renames it into place
- `Load` backs up an unparsable config to `config.json.corrupted` and boots with defaults instead of failing
- The WebView2 user data folder moves from `%APPDATA%` to `%LOCALAPPDATA%\ghost-chat\webview`, per Microsoft guidance against keeping it in the roaming profile

## Vanish mode grey box

Vanish mode on Windows showed a solid grey box instead of a transparent overlay. `DisableFramelessWindowDecorations: true` stops Wails from extending the DWM frame into the client area on every `WM_ACTIVATE` (the likely culprit), and `BackgroundColour: NewRGBA(0, 0, 0, 0)` pins the WebView2 backdrop to zero alpha. Note this also removes the aero shadow / Windows 11 rounded corners, which is desirable for an overlay.

## Deviations from the fork

- Dropped the `os.Remove` before `os.Rename` — Go's rename already replaces existing files on Windows via `MOVEFILE_REPLACE_EXISTING`, and removing first only widens the crash window
- Deduplicated the corruption-recovery logic into a `recoverCorrupted` helper
- Skipped `KNOWLEDGE_BASE.md`

## Verification

- [x] `go test ./...` and `go build ./...` pass on macOS
- [x] Windows: app starts after planting garbage in `%APPDATA%\ghost-chat\config.json` (backup lands in `config.json.corrupted`)
- [x] Windows: vanish mode shows the desktop through, no grey box

🤖 Generated with [Claude Code](https://claude.com/claude-code)