### PR TITLE
feat(ci): automatic release versioning with rc support

### DIFF
--- a/.github/scripts/next-version.sh
+++ b/.github/scripts/next-version.sh
@@ -10,6 +10,11 @@ while [ $# -gt 0 ]; do
       rc=true
       ;;
     --override)
+      if [ -z "${2:-}" ]; then
+        echo "--override requires a value" >&2
+        exit 1
+      fi
+
       override="$2"
       shift
       ;;
@@ -36,9 +41,14 @@ fi
 subjects="$(git log --format=%s "${last_stable}..HEAD")"
 bodies="$(git log --format=%b "${last_stable}..HEAD")"
 
+if [ -z "$subjects" ]; then
+  echo "no commits since ${last_stable}" >&2
+  exit 1
+fi
+
 bump=patch
 
-if echo "$subjects" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$bodies" | grep -qE 'BREAKING[ -]CHANGE'; then
+if echo "$subjects" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$bodies" | grep -qE '^BREAKING[ -]CHANGE: '; then
   bump=major
 elif echo "$subjects" | grep -qE '^feat(\(.+\))?:'; then
   bump=minor

--- a/.github/scripts/next-version.sh
+++ b/.github/scripts/next-version.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rc=false
+override=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rc)
+      rc=true
+      ;;
+    --override)
+      override="$2"
+      shift
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$override" ]; then
+  echo "$override"
+  exit 0
+fi
+
+last_stable="$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+
+if [ -z "$last_stable" ]; then
+  echo "no stable tag found" >&2
+  exit 1
+fi
+
+subjects="$(git log --format=%s "${last_stable}..HEAD")"
+bodies="$(git log --format=%b "${last_stable}..HEAD")"
+
+bump=patch
+
+if echo "$subjects" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$bodies" | grep -qE 'BREAKING[ -]CHANGE'; then
+  bump=major
+elif echo "$subjects" | grep -qE '^feat(\(.+\))?:'; then
+  bump=minor
+fi
+
+IFS=. read -r major minor patch <<<"${last_stable#v}"
+
+case "$bump" in
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  patch)
+    patch=$((patch + 1))
+    ;;
+esac
+
+next="v${major}.${minor}.${patch}"
+
+if [ "$rc" = true ]; then
+  last_rc="$(git tag --list "${next}-rc.*" | sed "s/.*-rc\.//" | sort -n | tail -n 1)"
+  next="${next}-rc.$((${last_rc:-0} + 1))"
+fi
+
+echo "$next"

--- a/.github/scripts/next-version.test.sh
+++ b/.github/scripts/next-version.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="$(cd "$(dirname "$0")" && pwd)/next-version.sh"
+failures=0
+
+assert_version() {
+  local expected="$1"
+  shift
+
+  local actual
+  actual="$(bash "$script" "$@" 2>&1)" || true
+
+  if [ "$actual" = "$expected" ]; then
+    echo "ok: [$*] -> $actual"
+  else
+    echo "FAIL: [$*] -> $actual (expected $expected)"
+    failures=$((failures + 1))
+  fi
+}
+
+repo="$(mktemp -d)"
+trap 'rm -rf "$repo"' EXIT
+
+cd "$repo"
+
+git init -q
+git config user.email test@test.invalid
+git config user.name test
+git config commit.gpgsign false
+
+commit() {
+  git commit -q --allow-empty "$@"
+}
+
+commit -m "chore: init"
+git tag v4.2.0
+
+commit -m "docs: readme"
+assert_version v4.2.1
+assert_version v4.2.1-rc.1 --rc
+
+commit -m "feat(windows): scoped feature"
+assert_version v4.3.0
+assert_version v4.3.0-rc.1 --rc
+
+git tag v4.3.0-rc.1
+assert_version v4.3.0-rc.2 --rc
+assert_version v4.3.0
+
+commit -m "feat!: breaking subject"
+assert_version v5.0.0
+assert_version v5.0.0-rc.1 --rc
+
+git tag v5.0.0
+commit -m "fix(youtube): thing" -m "BREAKING CHANGE: api changed"
+assert_version v6.0.0
+
+git tag v6.0.0
+commit -m "Architecture seams: non-conventional subject"
+assert_version v6.0.1
+
+assert_version v9.9.9 --override v9.9.9
+assert_version v9.9.9 --rc --override v9.9.9
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+
+echo "all assertions passed"

--- a/.github/scripts/next-version.test.sh
+++ b/.github/scripts/next-version.test.sh
@@ -60,8 +60,17 @@ git tag v6.0.0
 commit -m "Architecture seams: non-conventional subject"
 assert_version v6.0.1
 
+commit -m "chore: casual mention" -m "note: this is not a BREAKING CHANGE, just a refactor"
+assert_version v6.0.1
+
 assert_version v9.9.9 --override v9.9.9
 assert_version v9.9.9 --rc --override v9.9.9
+
+git tag v7.0.0
+assert_version "no commits since v7.0.0"
+
+assert_version "--override requires a value" --override
+assert_version "--override requires a value" --override ""
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed"

--- a/.github/workflows/quick-checks.yml
+++ b/.github/workflows/quick-checks.yml
@@ -10,6 +10,8 @@ on:
       - "go.mod"
       - "go.sum"
       - "frontend/**"
+  pull_request:
+    types: [opened, edited, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +19,7 @@ concurrency:
 
 jobs:
   checks:
+    if: github.event_name == 'push'
     runs-on: macos-latest
 
     steps:
@@ -48,3 +51,15 @@ jobs:
 
       - run: pnpm build
         working-directory: frontend
+
+  pr-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,17 +4,50 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v4.0.1)"
-        required: true
-
-env:
-  VERSION_TAG: ${{ github.event.inputs.version }}
+        description: "Version override (e.g. v4.0.1) — leave empty to auto-detect from commits"
+        required: false
+      release-candidate:
+        description: "Draft a release candidate (vX.Y.Z-rc.N, marked as prerelease)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
+  determine-version:
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: version
+        env:
+          RC: ${{ inputs.release-candidate }}
+          OVERRIDE: ${{ inputs.version }}
+        run: |
+          args=()
+
+          if [ "$RC" = "true" ]; then
+            args+=(--rc)
+          fi
+
+          if [ -n "$OVERRIDE" ]; then
+            args+=(--override "$OVERRIDE")
+          fi
+
+          version="$(bash .github/scripts/next-version.sh "${args[@]}")"
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Release version: \`$version\`" >> "$GITHUB_STEP_SUMMARY"
+
   build-macos:
+    needs: determine-version
     runs-on: macos-latest
 
     steps:
@@ -41,7 +74,7 @@ jobs:
 
       - run: wails3 task darwin:package:universal
         env:
-          VERSION: ${{ env.VERSION_TAG }}
+          VERSION: ${{ needs.determine-version.outputs.version }}
 
       - name: Zip app bundle
         run: cd bin && zip -r ghost-chat-macos.zip ghost-chat.app
@@ -52,6 +85,7 @@ jobs:
           path: bin/ghost-chat-macos.zip
 
   build-windows:
+    needs: determine-version
     runs-on: windows-latest
 
     steps:
@@ -78,7 +112,7 @@ jobs:
 
       - run: wails3 task build
         env:
-          VERSION: ${{ env.VERSION_TAG }}
+          VERSION: ${{ needs.determine-version.outputs.version }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -86,8 +120,11 @@ jobs:
           path: bin/ghost-chat.exe
 
   create-release:
-    needs: [build-macos, build-windows]
+    needs: [determine-version, build-macos, build-windows]
     runs-on: ubuntu-latest
+
+    env:
+      VERSION_TAG: ${{ needs.determine-version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v6
@@ -134,8 +171,9 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.VERSION_TAG }}
+          tag_name: ${{ needs.determine-version.outputs.version }}
           draft: true
+          prerelease: ${{ inputs.release-candidate }}
           generate_release_notes: true
           append_body: true
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
 permissions:
   contents: write
 
+concurrency: release
+
 jobs:
   determine-version:
     runs-on: ubuntu-latest
@@ -26,7 +28,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: version
+      - name: Compute release version
+        id: version
         env:
           RC: ${{ inputs.release-candidate }}
           OVERRIDE: ${{ inputs.version }}
@@ -42,6 +45,11 @@ jobs:
           fi
 
           version="$(bash .github/scripts/next-version.sh "${args[@]}")"
+
+          if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+            echo "tag $version already exists" >&2
+            exit 1
+          fi
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Release version: \`$version\`" >> "$GITHUB_STEP_SUMMARY"
@@ -171,7 +179,7 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.determine-version.outputs.version }}
+          tag_name: ${{ env.VERSION_TAG }}
           draft: true
           prerelease: ${{ inputs.release-candidate }}
           generate_release_notes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ wails3 task package       # .app bundle (macOS) or .exe (Windows)
 1. Fork the repo
 2. Create a branch for your feature or fix
 3. Make changes, ensure tests pass and linting is clean
-4. Push and open a Pull Request
+4. Push and open a Pull Request with a [conventional commit](https://www.conventionalcommits.org/) title, e.g. `fix(windows): ...` or `feat: ...` — PRs are squash-merged, and the title becomes the commit that determines the next release version
 
 Merge the latest from upstream before submitting.
 

--- a/docs/superpowers/plans/2026-06-10-automatic-release-versioning.md
+++ b/docs/superpowers/plans/2026-06-10-automatic-release-versioning.md
@@ -1,0 +1,405 @@
+# Automatic Release Versioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Derive the release version automatically from conventional commits since the last stable tag, with a release-candidate checkbox and a manual override, plus PR-title linting to keep commit subjects conventional.
+
+**Architecture:** A standalone bash script (`.github/scripts/next-version.sh`) owns the version logic and is covered by a scratch-repo test script. The release workflow gains a `determine-version` job whose output feeds the existing build/release jobs. `quick-checks.yml` gains a `pull_request`-triggered job that lints PR titles.
+
+**Tech Stack:** Bash, git, GitHub Actions, `amannn/action-semantic-pull-request`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-automatic-release-versioning-design.md`
+
+---
+
+## Version rules (from the spec)
+
+- Baseline = highest stable tag matching `vX.Y.Z` (prerelease tags like `v4.2.0-rc.1` are never the baseline).
+- Bump is always at least **patch**. Any `feat:`/`feat(scope):` subject since baseline → **minor**. Any `type!:`/`type(scope)!:` subject or `BREAKING CHANGE`/`BREAKING-CHANGE` in a body → **major**.
+- `--rc` appends `-rc.N` where N = highest existing `-rc.*` tag for the computed base version + 1 (or 1).
+- `--override <version>` prints the override verbatim and skips everything, including `--rc`.
+
+---
+
+### Task 1: Version script with tests
+
+**Files:**
+- Create: `.github/scripts/next-version.test.sh`
+- Create: `.github/scripts/next-version.sh`
+
+- [ ] **Step 1: Write the failing test script**
+
+Create `.github/scripts/next-version.test.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="$(cd "$(dirname "$0")" && pwd)/next-version.sh"
+failures=0
+
+assert_version() {
+  local expected="$1"
+  shift
+
+  local actual
+  actual="$(bash "$script" "$@" 2>&1)" || true
+
+  if [ "$actual" = "$expected" ]; then
+    echo "ok: [$*] -> $actual"
+  else
+    echo "FAIL: [$*] -> $actual (expected $expected)"
+    failures=$((failures + 1))
+  fi
+}
+
+repo="$(mktemp -d)"
+trap 'rm -rf "$repo"' EXIT
+
+cd "$repo"
+
+git init -q
+git config user.email test@test.invalid
+git config user.name test
+git config commit.gpgsign false
+
+commit() {
+  git commit -q --allow-empty "$@"
+}
+
+commit -m "chore: init"
+git tag v4.2.0
+
+commit -m "docs: readme"
+assert_version v4.2.1
+assert_version v4.2.1-rc.1 --rc
+
+commit -m "feat(windows): scoped feature"
+assert_version v4.3.0
+assert_version v4.3.0-rc.1 --rc
+
+git tag v4.3.0-rc.1
+assert_version v4.3.0-rc.2 --rc
+assert_version v4.3.0
+
+commit -m "feat!: breaking subject"
+assert_version v5.0.0
+assert_version v5.0.0-rc.1 --rc
+
+git tag v5.0.0
+commit -m "fix(youtube): thing" -m "BREAKING CHANGE: api changed"
+assert_version v6.0.0
+
+git tag v6.0.0
+commit -m "Architecture seams: non-conventional subject"
+assert_version v6.0.1
+
+assert_version v9.9.9 --override v9.9.9
+assert_version v9.9.9 --rc --override v9.9.9
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+
+echo "all assertions passed"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bash .github/scripts/next-version.test.sh`
+Expected: every assertion prints `FAIL` (the script under test does not exist yet), final line `12 assertion(s) failed`, exit code 1.
+
+- [ ] **Step 3: Write the version script**
+
+Create `.github/scripts/next-version.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+rc=false
+override=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rc)
+      rc=true
+      ;;
+    --override)
+      override="$2"
+      shift
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$override" ]; then
+  echo "$override"
+  exit 0
+fi
+
+last_stable="$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+
+if [ -z "$last_stable" ]; then
+  echo "no stable tag found" >&2
+  exit 1
+fi
+
+subjects="$(git log --format=%s "${last_stable}..HEAD")"
+bodies="$(git log --format=%b "${last_stable}..HEAD")"
+
+bump=patch
+
+if echo "$subjects" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$bodies" | grep -qE 'BREAKING[ -]CHANGE'; then
+  bump=major
+elif echo "$subjects" | grep -qE '^feat(\(.+\))?:'; then
+  bump=minor
+fi
+
+IFS=. read -r major minor patch <<<"${last_stable#v}"
+
+case "$bump" in
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  patch)
+    patch=$((patch + 1))
+    ;;
+esac
+
+next="v${major}.${minor}.${patch}"
+
+if [ "$rc" = true ]; then
+  last_rc="$(git tag --list "${next}-rc.*" | sed "s/.*-rc\.//" | sort -n | tail -n 1)"
+  next="${next}-rc.$((${last_rc:-0} + 1))"
+fi
+
+echo "$next"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bash .github/scripts/next-version.test.sh`
+Expected: 12 `ok:` lines, final line `all assertions passed`, exit code 0.
+
+- [ ] **Step 5: Sanity-check against the real repo**
+
+Run from the repo root: `bash .github/scripts/next-version.sh` and `bash .github/scripts/next-version.sh --rc`
+Expected: last stable tag is `v4.2.0`; commits since include `fix(windows): ...` (#1292) but no `feat:` → output `v4.2.1` and `v4.2.1-rc.1`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/scripts/next-version.sh .github/scripts/next-version.test.sh
+git commit -m "feat(ci): add commit-based version detection script"
+```
+
+---
+
+### Task 2: Wire the script into the release workflow
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Replace the inputs and add the determine-version job**
+
+In `.github/workflows/release.yml`, replace the `on:`/`env:` header (lines 1-14) with:
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version override (e.g. v4.0.1) — leave empty to auto-detect from commits"
+        required: false
+      release-candidate:
+        description: "Draft a release candidate (vX.Y.Z-rc.N, marked as prerelease)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+```
+
+Note the global `env: VERSION_TAG` block is removed — jobs read the version from the new job's output instead.
+
+Then add this as the first job under `jobs:`:
+
+```yaml
+  determine-version:
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: version
+        env:
+          RC: ${{ inputs.release-candidate }}
+          OVERRIDE: ${{ inputs.version }}
+        run: |
+          args=()
+
+          if [ "$RC" = "true" ]; then
+            args+=(--rc)
+          fi
+
+          if [ -n "$OVERRIDE" ]; then
+            args+=(--override "$OVERRIDE")
+          fi
+
+          version="$(bash .github/scripts/next-version.sh "${args[@]}")"
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Release version: \`$version\`" >> "$GITHUB_STEP_SUMMARY"
+```
+
+- [ ] **Step 2: Point the build jobs at the job output**
+
+In `build-macos`, add `needs: determine-version` directly under the job key, and change the package step's env:
+
+```yaml
+  build-macos:
+    needs: determine-version
+    runs-on: macos-latest
+```
+
+```yaml
+      - run: wails3 task darwin:package:universal
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+```
+
+Same for `build-windows`:
+
+```yaml
+  build-windows:
+    needs: determine-version
+    runs-on: windows-latest
+```
+
+```yaml
+      - run: wails3 task build
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+```
+
+- [ ] **Step 3: Update create-release**
+
+Change the job header so the shell steps keep reading `$VERSION_TAG`, now sourced from the job output:
+
+```yaml
+  create-release:
+    needs: [determine-version, build-macos, build-windows]
+    runs-on: ubuntu-latest
+
+    env:
+      VERSION_TAG: ${{ needs.determine-version.outputs.version }}
+```
+
+In the `softprops/action-gh-release@v2` step, update `tag_name` and add `prerelease` (the rest of the step is unchanged):
+
+```yaml
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.determine-version.outputs.version }}
+          draft: true
+          prerelease: ${{ inputs.release-candidate }}
+          generate_release_notes: true
+```
+
+- [ ] **Step 4: Verify there are no leftover references to the old input**
+
+Run: `grep -n "github.event.inputs" .github/workflows/release.yml`
+Expected: no matches (the new syntax uses `inputs.*`; `determine-version` is the only consumer of the raw inputs besides `prerelease`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "feat(ci): auto-detect release version with rc support"
+```
+
+---
+
+### Task 3: PR title lint in quick checks
+
+**Files:**
+- Modify: `.github/workflows/quick-checks.yml`
+
+- [ ] **Step 1: Add the pull_request trigger and the pr-title job**
+
+In `.github/workflows/quick-checks.yml`, extend the `on:` block:
+
+```yaml
+on:
+  push:
+    branches:
+      - "**"
+      - "!main"
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "frontend/**"
+  pull_request:
+    types: [opened, edited, synchronize]
+```
+
+Guard the existing job so it only runs on pushes (add one line under `checks:`):
+
+```yaml
+jobs:
+  checks:
+    if: github.event_name == 'push'
+    runs-on: macos-latest
+```
+
+Add the new job at the end of the file:
+
+```yaml
+  pr-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/quick-checks.yml
+git commit -m "feat(ci): lint pr titles for conventional commits"
+```
+
+---
+
+## Post-merge verification
+
+Workflow changes can't run locally. After merging:
+
+1. Dispatch **Release** with `release-candidate` checked and `version` empty. Confirm the job summary shows the expected `-rc.N` version, the release is draft + prerelease, and the tag was pushed.
+2. Open a test PR with a non-conventional title and confirm `pr-title` fails; rename it to `chore: test` and confirm it passes.

--- a/docs/superpowers/plans/2026-06-10-automatic-release-versioning.md
+++ b/docs/superpowers/plans/2026-06-10-automatic-release-versioning.md
@@ -94,8 +94,17 @@ git tag v6.0.0
 commit -m "Architecture seams: non-conventional subject"
 assert_version v6.0.1
 
+commit -m "chore: casual mention" -m "note: this is not a BREAKING CHANGE, just a refactor"
+assert_version v6.0.1
+
 assert_version v9.9.9 --override v9.9.9
 assert_version v9.9.9 --rc --override v9.9.9
+
+git tag v7.0.0
+assert_version "no commits since v7.0.0"
+
+assert_version "--override requires a value" --override
+assert_version "--override requires a value" --override ""
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed"
@@ -108,7 +117,7 @@ echo "all assertions passed"
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `bash .github/scripts/next-version.test.sh`
-Expected: every assertion prints `FAIL` (the script under test does not exist yet), final line `12 assertion(s) failed`, exit code 1.
+Expected: every assertion prints `FAIL` (the script under test does not exist yet), final line `16 assertion(s) failed`, exit code 1.
 
 - [ ] **Step 3: Write the version script**
 
@@ -127,6 +136,11 @@ while [ $# -gt 0 ]; do
       rc=true
       ;;
     --override)
+      if [ -z "${2:-}" ]; then
+        echo "--override requires a value" >&2
+        exit 1
+      fi
+
       override="$2"
       shift
       ;;
@@ -153,9 +167,14 @@ fi
 subjects="$(git log --format=%s "${last_stable}..HEAD")"
 bodies="$(git log --format=%b "${last_stable}..HEAD")"
 
+if [ -z "$subjects" ]; then
+  echo "no commits since ${last_stable}" >&2
+  exit 1
+fi
+
 bump=patch
 
-if echo "$subjects" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$bodies" | grep -qE 'BREAKING[ -]CHANGE'; then
+if echo "$subjects" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$bodies" | grep -qE '^BREAKING[ -]CHANGE: '; then
   bump=major
 elif echo "$subjects" | grep -qE '^feat(\(.+\))?:'; then
   bump=minor
@@ -191,7 +210,7 @@ echo "$next"
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `bash .github/scripts/next-version.test.sh`
-Expected: 12 `ok:` lines, final line `all assertions passed`, exit code 0.
+Expected: 16 `ok:` lines, final line `all assertions passed`, exit code 0.
 
 - [ ] **Step 5: Sanity-check against the real repo**
 

--- a/docs/superpowers/plans/2026-06-10-automatic-release-versioning.md
+++ b/docs/superpowers/plans/2026-06-10-automatic-release-versioning.md
@@ -215,7 +215,7 @@ Expected: 16 `ok:` lines, final line `all assertions passed`, exit code 0.
 - [ ] **Step 5: Sanity-check against the real repo**
 
 Run from the repo root: `bash .github/scripts/next-version.sh` and `bash .github/scripts/next-version.sh --rc`
-Expected: last stable tag is `v4.2.0`; commits since include `fix(windows): ...` (#1292) but no `feat:` → output `v4.2.1` and `v4.2.1-rc.1`.
+Expected: last stable tag is `v4.2.0`; commits since include `fix(windows): ...` (#1292) but no `feat:` → output `v4.2.1` and `v4.2.1-rc.1`. (This held at execution time; once this branch's own `feat(ci):` commits exist, the same commands correctly yield `v4.3.0`.)
 
 - [ ] **Step 6: Commit**
 
@@ -251,9 +251,11 @@ on:
 
 permissions:
   contents: write
+
+concurrency: release
 ```
 
-Note the global `env: VERSION_TAG` block is removed — jobs read the version from the new job's output instead.
+Note the global `env: VERSION_TAG` block is removed — jobs read the version from the new job's output instead. The `concurrency` group queues a second dispatch behind a running release instead of letting them race.
 
 Then add this as the first job under `jobs:`:
 
@@ -269,7 +271,8 @@ Then add this as the first job under `jobs:`:
         with:
           fetch-depth: 0
 
-      - id: version
+      - name: Compute release version
+        id: version
         env:
           RC: ${{ inputs.release-candidate }}
           OVERRIDE: ${{ inputs.version }}
@@ -286,9 +289,16 @@ Then add this as the first job under `jobs:`:
 
           version="$(bash .github/scripts/next-version.sh "${args[@]}")"
 
+          if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+            echo "tag $version already exists" >&2
+            exit 1
+          fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Release version: \`$version\`" >> "$GITHUB_STEP_SUMMARY"
 ```
+
+The tag-existence check fails the run in seconds (e.g. a duplicate override) instead of after both platform builds.
 
 - [ ] **Step 2: Point the build jobs at the job output**
 
@@ -338,7 +348,7 @@ In the `softprops/action-gh-release@v2` step, update `tag_name` and add `prerele
 ```yaml
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.determine-version.outputs.version }}
+          tag_name: ${{ env.VERSION_TAG }}
           draft: true
           prerelease: ${{ inputs.release-candidate }}
           generate_release_notes: true

--- a/docs/superpowers/specs/2026-06-10-automatic-release-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-10-automatic-release-versioning-design.md
@@ -37,7 +37,8 @@ Logic:
 2. Find the last stable tag: highest `v*.*.*` tag excluding prereleases (version sort).
 3. Scan commits in `<last-stable>..HEAD` (subjects via `--format=%s`, bodies via `%b` for
    the breaking-change check):
-   - any subject matching `^[a-z]+(\(.+\))?!:` or body containing `BREAKING CHANGE` → major
+   - any subject matching `^[a-z]+(\(.+\))?!:` or a body line starting with `BREAKING CHANGE: `
+     or `BREAKING-CHANGE: ` (a conventional-commits footer) → major
    - else any subject matching `^feat(\(.+\))?:` → minor
    - else → patch (always at least patch; non-conventional subjects land here)
 4. Apply the bump to the last stable version.
@@ -62,6 +63,8 @@ Logic:
 ## Error handling
 
 - No stable tag found: script exits with an error (this repo always has stable tags).
+- No commits since the last stable tag: script exits with an error instead of minting a
+  pointless patch release.
 - Override version given alongside the RC checkbox: the override wins verbatim; the script
   does not append `-rc.N` to an override.
 - Tag collision (computed tag already exists): `git push origin <tag>` in `create-release`

--- a/docs/superpowers/specs/2026-06-10-automatic-release-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-10-automatic-release-versioning-design.md
@@ -66,9 +66,14 @@ Logic:
 - No commits since the last stable tag: script exits with an error instead of minting a
   pointless patch release.
 - Override version given alongside the RC checkbox: the override wins verbatim; the script
-  does not append `-rc.N` to an override.
-- Tag collision (computed tag already exists): `git push origin <tag>` in `create-release`
-  fails the workflow, which is the desired signal that something is off.
+  does not append `-rc.N` to an override. The GitHub release is still marked prerelease in
+  that combination, since the checkbox drives the `prerelease` flag independently.
+- Tag collision (computed or overridden tag already exists): the `determine-version` job
+  checks `git rev-parse --verify refs/tags/<tag>` and fails fast, before any platform build
+  runs.
+- Concurrent dispatches: a workflow-level `concurrency: release` group queues a second run
+  behind the first; the queued run then fails the collision check after the first one pushes
+  its tag.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-10-automatic-release-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-10-automatic-release-versioning-design.md
@@ -1,0 +1,76 @@
+# Automatic Release Versioning
+
+## Problem
+
+The release workflow (`.github/workflows/release.yml`) requires manually typing a version
+string on every dispatch. The version should instead be derived from the commits since the
+last release, with an option to cut a release candidate.
+
+## Decisions
+
+- **Bump rule:** a release always bumps at least **patch**. Conventional commit subjects
+  escalate the bump: `feat:` → minor, `feat!:` / `BREAKING CHANGE` → major. Non-conventional
+  commits count as patch-level. `chore:`/`docs:`/etc. never block a release.
+- **Baseline:** the bump is always computed from the last **stable** tag (`vX.Y.Z`, excluding
+  `-rc.*`). A final release after RCs recomputes from the last stable tag, so commits landed
+  after an RC can still escalate the version (e.g. `v4.3.0-rc.2` + later `feat!:` → `v5.0.0`).
+- **Release candidates:** a `release-candidate` checkbox input appends `-rc.N` to the computed
+  version. `N` auto-increments past existing RC tags for the same base version
+  (`v4.3.0-rc.1` exists → next RC is `v4.3.0-rc.2`). RC releases are marked **prerelease**
+  on GitHub in addition to draft.
+- **Manual override:** the existing `version` input becomes optional. When set, it is used
+  verbatim and all auto-detection is skipped.
+- **Conventional commit enforcement:** PR titles are linted in `quick-checks.yml` so
+  squash-merge commit subjects stay conventional. This keeps bump detection and generated
+  release notes accurate. Local commits inside a PR are not policed.
+
+## Components
+
+### `.github/scripts/next-version.sh`
+
+Bash script, runnable locally. Inputs via arguments or env: RC mode flag, optional override
+version. Output: the computed tag (e.g. `v4.3.0` or `v4.3.0-rc.2`) on stdout.
+
+Logic:
+
+1. If an override version is given, print it and exit.
+2. Find the last stable tag: highest `v*.*.*` tag excluding prereleases (version sort).
+3. Scan commits in `<last-stable>..HEAD` (subjects via `--format=%s`, bodies via `%b` for
+   the breaking-change check):
+   - any subject matching `^[a-z]+(\(.+\))?!:` or body containing `BREAKING CHANGE` → major
+   - else any subject matching `^feat(\(.+\))?:` → minor
+   - else → patch (always at least patch; non-conventional subjects land here)
+4. Apply the bump to the last stable version.
+5. If RC mode: find existing `v<base>-rc.*` tags, append `-rc.<max+1>` (or `-rc.1` if none).
+
+### `.github/workflows/release.yml`
+
+- Inputs: `version` (optional override), `release-candidate` (boolean, default false).
+- New first job `determine-version`: checkout with `fetch-depth: 0`, run the script, expose
+  the result as a job output, print it in the job summary (`$GITHUB_STEP_SUMMARY`).
+- `build-macos`, `build-windows`, `create-release` depend on `determine-version` and use
+  `needs.determine-version.outputs.version` everywhere `VERSION_TAG` is used today.
+- `create-release` passes `prerelease: ${{ inputs.release-candidate }}` to
+  `softprops/action-gh-release` (draft stays on).
+
+### `.github/workflows/quick-checks.yml`
+
+- New job using `amannn/action-semantic-pull-request` to lint PR titles against
+  conventional commit types. Runs on `pull_request` title-affecting events
+  (`opened`, `edited`, `synchronize`).
+
+## Error handling
+
+- No stable tag found: script exits with an error (this repo always has stable tags).
+- Override version given alongside the RC checkbox: the override wins verbatim; the script
+  does not append `-rc.N` to an override.
+- Tag collision (computed tag already exists): `git push origin <tag>` in `create-release`
+  fails the workflow, which is the desired signal that something is off.
+
+## Testing
+
+- Script is plain bash over `git log`/`git tag`, testable locally against the real repo
+  history (e.g. verify it computes the expected next version) and in a scratch repo with
+  synthetic tags/commits covering: patch-only commits, `feat:`, `feat!:`, RC increment,
+  final-after-RC, and override.
+- Workflow changes are validated by dispatching an RC release once merged.


### PR DESCRIPTION
## Summary
- New `.github/scripts/next-version.sh` computes the next release tag from conventional commits since the last stable tag: always at least a patch bump, `feat:` escalates to minor, `!`-subjects or `BREAKING CHANGE:` footers to major; `--rc` appends an auto-incrementing `-rc.N`; covered by a 16-assertion scratch-repo test suite
- The Release workflow now auto-detects the version via a `determine-version` job (the old `version` input remains as an optional override), adds a `release-candidate` checkbox that marks the draft release as prerelease, fails fast on tag collisions, and queues concurrent dispatches
- Quick Checks gains a `pr-title` job (`amannn/action-semantic-pull-request`) so squash-merge commit subjects stay conventional; CONTRIBUTING.md documents the new title requirement

Design spec and implementation plan included under `docs/superpowers/`.

## Test Plan
- [x] `bash .github/scripts/next-version.test.sh` — 16/16 assertions pass
- [x] `go test ./...` — all green
- [ ] After merge: dispatch Release with `release-candidate` checked and `version` empty; expect a draft prerelease tagged `v4.3.0-rc.1` and the version shown in the job summary
- [ ] After merge: open a test PR with a non-conventional title, confirm `pr-title` fails, rename to `chore: test`, confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)