### PR TITLE
feat: custom source iframe rendering

### DIFF
--- a/frontend/bindings/ghost-chat/internal/config/index.ts
+++ b/frontend/bindings/ghost-chat/internal/config/index.ts
@@ -3,6 +3,7 @@
 
 export {
     Config,
+    CustomSource,
     General,
     Keybinds,
     KickConfig,

--- a/frontend/bindings/ghost-chat/internal/config/models.ts
+++ b/frontend/bindings/ghost-chat/internal/config/models.ts
@@ -14,6 +14,7 @@ export class Config {
     "twitch": TwitchConfig;
     "youtube": YouTubeConfig;
     "kick": KickConfig;
+    "custom_source": CustomSource;
 
     /** Creates a new Config instance. */
     constructor($$source: Partial<Config> = {}) {
@@ -41,6 +42,9 @@ export class Config {
         if (!("kick" in $$source)) {
             this["kick"] = (new KickConfig());
         }
+        if (!("custom_source" in $$source)) {
+            this["custom_source"] = (new CustomSource());
+        }
 
         Object.assign(this, $$source);
     }
@@ -56,6 +60,7 @@ export class Config {
         const $$createField5_0 = $$createType4;
         const $$createField6_0 = $$createType5;
         const $$createField7_0 = $$createType6;
+        const $$createField8_0 = $$createType7;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("window_state" in $$parsedSource) {
             $$parsedSource["window_state"] = $$createField1_0($$parsedSource["window_state"]);
@@ -78,7 +83,31 @@ export class Config {
         if ("kick" in $$parsedSource) {
             $$parsedSource["kick"] = $$createField7_0($$parsedSource["kick"]);
         }
+        if ("custom_source" in $$parsedSource) {
+            $$parsedSource["custom_source"] = $$createField8_0($$parsedSource["custom_source"]);
+        }
         return new Config($$parsedSource as Partial<Config>);
+    }
+}
+
+export class CustomSource {
+    "url": string;
+
+    /** Creates a new CustomSource instance. */
+    constructor($$source: Partial<CustomSource> = {}) {
+        if (!("url" in $$source)) {
+            this["url"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new CustomSource instance from a string or object.
+     */
+    static createFrom($$source: any = {}): CustomSource {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new CustomSource($$parsedSource as Partial<CustomSource>);
     }
 }
 
@@ -130,7 +159,7 @@ export class Keybinds {
      * Creates a new Keybinds instance from a string or object.
      */
     static createFrom($$source: any = {}): Keybinds {
-        const $$createField0_0 = $$createType7;
+        const $$createField0_0 = $$createType8;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("vanish" in $$parsedSource) {
             $$parsedSource["vanish"] = $$createField0_0($$parsedSource["vanish"]);
@@ -167,7 +196,7 @@ export class KickConfig {
      * Creates a new KickConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): KickConfig {
-        const $$createField3_0 = $$createType8;
+        const $$createField3_0 = $$createType9;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("user_blacklist" in $$parsedSource) {
             $$parsedSource["user_blacklist"] = $$createField3_0($$parsedSource["user_blacklist"]);
@@ -297,7 +326,7 @@ export class ThemeConfig {
      * Creates a new ThemeConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): ThemeConfig {
-        const $$createField1_0 = $$createType10;
+        const $$createField1_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("custom_themes" in $$parsedSource) {
             $$parsedSource["custom_themes"] = $$createField1_0($$parsedSource["custom_themes"]);
@@ -350,8 +379,8 @@ export class TwitchConfig {
      * Creates a new TwitchConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): TwitchConfig {
-        const $$createField6_0 = $$createType8;
-        const $$createField7_0 = $$createType11;
+        const $$createField6_0 = $$createType9;
+        const $$createField7_0 = $$createType12;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("user_blacklist" in $$parsedSource) {
             $$parsedSource["user_blacklist"] = $$createField6_0($$parsedSource["user_blacklist"]);
@@ -485,7 +514,7 @@ export class YouTubeConfig {
      * Creates a new YouTubeConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): YouTubeConfig {
-        const $$createField4_0 = $$createType8;
+        const $$createField4_0 = $$createType9;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("user_blacklist" in $$parsedSource) {
             $$parsedSource["user_blacklist"] = $$createField4_0($$parsedSource["user_blacklist"]);
@@ -502,8 +531,9 @@ const $$createType3 = ThemeConfig.createFrom;
 const $$createType4 = TwitchConfig.createFrom;
 const $$createType5 = YouTubeConfig.createFrom;
 const $$createType6 = KickConfig.createFrom;
-const $$createType7 = VanishKeybind.createFrom;
-const $$createType8 = $Create.Array($Create.Any);
-const $$createType9 = Theme.createFrom;
-const $$createType10 = $Create.Array($$createType9);
-const $$createType11 = TwitchEvents.createFrom;
+const $$createType7 = CustomSource.createFrom;
+const $$createType8 = VanishKeybind.createFrom;
+const $$createType9 = $Create.Array($Create.Any);
+const $$createType10 = Theme.createFrom;
+const $$createType11 = $Create.Array($$createType10);
+const $$createType12 = TwitchEvents.createFrom;

--- a/frontend/public/locales/de-DE/translation.json
+++ b/frontend/public/locales/de-DE/translation.json
@@ -21,14 +21,15 @@
             "kick_channel": "Kanalname"
         },
         "custom_source": {
-            "label": "Custom Overlay",
+            "label": "Eigenes Overlay",
             "placeholder": "https://your-overlay.example.com",
-            "open": "Open Overlay",
-            "hint": "Some sites block embedding and may render blank."
+            "open": "Overlay öffnen",
+            "hint": "Manche Seiten blockieren das Einbetten und werden möglicherweise leer angezeigt."
         }
     },
     "chat": {
         "back": "Zurück",
+        "reload": "Neu laden",
         "waiting": "Warte auf Nachrichten...",
         "disconnected": "Getrennt",
         "scroll_to_bottom": "Nach unten scrollen",

--- a/frontend/public/locales/de-DE/translation.json
+++ b/frontend/public/locales/de-DE/translation.json
@@ -19,6 +19,12 @@
             "channel_id": "Kanal-ID",
             "channel_or_url": "Kanal, @handle oder Video-URL",
             "kick_channel": "Kanalname"
+        },
+        "custom_source": {
+            "label": "Custom Overlay",
+            "placeholder": "https://your-overlay.example.com",
+            "open": "Open Overlay",
+            "hint": "Some sites block embedding and may render blank."
         }
     },
     "chat": {

--- a/frontend/public/locales/en-US/translation.json
+++ b/frontend/public/locales/en-US/translation.json
@@ -29,6 +29,7 @@
     },
     "chat": {
         "back": "Back",
+        "reload": "Reload",
         "waiting": "Waiting for messages...",
         "disconnected": "Disconnected",
         "scroll_to_bottom": "Scroll to bottom",

--- a/frontend/public/locales/en-US/translation.json
+++ b/frontend/public/locales/en-US/translation.json
@@ -19,6 +19,12 @@
             "channel_id": "Channel ID",
             "channel_or_url": "Channel, @handle, or video URL",
             "kick_channel": "Channel name"
+        },
+        "custom_source": {
+            "label": "Custom Overlay",
+            "placeholder": "https://your-overlay.example.com",
+            "open": "Open Overlay",
+            "hint": "Some sites block embedding and may render blank."
         }
     },
     "chat": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { HashRouter, Routes, Route } from 'react-router-dom';
 
 import { Chat } from '@/components/Chat/Chat';
+import { CustomSource } from '@/components/CustomSource/CustomSource';
 import { Home } from '@/components/Home/Home';
 import { Settings } from '@/components/Settings/Settings';
 import { ThemePreview } from '@/components/Settings/ThemePreview';
@@ -127,6 +128,10 @@ function App() {
                                 <Route
                                     path="/chat"
                                     element={<Chat />}
+                                />
+                                <Route
+                                    path="/source"
+                                    element={<CustomSource />}
                                 />
                             </Routes>
                         </div>

--- a/frontend/src/components/CustomSource/CustomSource.module.css
+++ b/frontend/src/components/CustomSource/CustomSource.module.css
@@ -1,0 +1,52 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    :global([data-vanished]) & {
+        background: transparent;
+    }
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+
+    :global([data-vanished]) & {
+        visibility: hidden;
+    }
+}
+
+.vanishBtn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: var(--radius-sm);
+    color: var(--color-text-dim);
+    margin-left: auto;
+    transition:
+        color var(--transition-fast),
+        background var(--transition-fast);
+
+    &:hover {
+        color: var(--color-accent);
+        background: var(--color-bg-hover);
+    }
+}
+
+.iframeWrapper {
+    flex: 1;
+    background: transparent;
+}
+
+.iframe {
+    border: none;
+    width: 100%;
+    height: 100%;
+}

--- a/frontend/src/components/CustomSource/CustomSource.module.css
+++ b/frontend/src/components/CustomSource/CustomSource.module.css
@@ -43,6 +43,7 @@
 .iframeWrapper {
     flex: 1;
     background: transparent;
+    overflow: hidden;
 }
 
 .iframe {

--- a/frontend/src/components/CustomSource/CustomSource.tsx
+++ b/frontend/src/components/CustomSource/CustomSource.tsx
@@ -19,6 +19,7 @@ export function CustomSource() {
                 <button
                     className="btn btn-ghost"
                     onClick={() => navigate('/')}
+                    title="Back"
                 >
                     <svg
                         width="14"

--- a/frontend/src/components/CustomSource/CustomSource.tsx
+++ b/frontend/src/components/CustomSource/CustomSource.tsx
@@ -1,0 +1,91 @@
+import { ToggleVanish } from '@bindings/ghost-chat/app.js';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useConfigStore } from '@/stores/config';
+
+import styles from './CustomSource.module.css';
+
+export function CustomSource() {
+    const navigate = useNavigate();
+    const config = useConfigStore((s) => s.config);
+    const [reloadKey, setReloadKey] = useState(0);
+
+    const url = config?.custom_source?.url ?? '';
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.header}>
+                <button
+                    className="btn btn-ghost"
+                    onClick={() => navigate('/')}
+                >
+                    <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <polyline points="15 18 9 12 15 6" />
+                    </svg>
+                </button>
+                <button
+                    className="btn btn-ghost"
+                    onClick={() => setReloadKey((k) => k + 1)}
+                    title="Reload"
+                >
+                    <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <polyline points="1 4 1 10 7 10" />
+                        <path d="M3.51 15a9 9 0 1 0 .49-3.54" />
+                    </svg>
+                </button>
+                <button
+                    className={styles.vanishBtn}
+                    onClick={() => void ToggleVanish()}
+                    title="Vanish"
+                >
+                    <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                        <circle
+                            cx="12"
+                            cy="12"
+                            r="3"
+                        />
+                    </svg>
+                </button>
+            </div>
+            {url && (
+                <div className={styles.iframeWrapper}>
+                    <iframe
+                        key={reloadKey}
+                        src={url}
+                        title="Custom source"
+                        className={styles.iframe}
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/CustomSource/CustomSource.tsx
+++ b/frontend/src/components/CustomSource/CustomSource.tsx
@@ -1,5 +1,6 @@
 import { ToggleVanish } from '@bindings/ghost-chat/app.js';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { useConfigStore } from '@/stores/config';
@@ -7,6 +8,7 @@ import { useConfigStore } from '@/stores/config';
 import styles from './CustomSource.module.css';
 
 export function CustomSource() {
+    const { t } = useTranslation();
     const navigate = useNavigate();
     const config = useConfigStore((s) => s.config);
     const [reloadKey, setReloadKey] = useState(0);
@@ -19,7 +21,7 @@ export function CustomSource() {
                 <button
                     className="btn btn-ghost"
                     onClick={() => navigate('/')}
-                    title="Back"
+                    title={t('chat.back')}
                 >
                     <svg
                         width="14"
@@ -37,7 +39,7 @@ export function CustomSource() {
                 <button
                     className="btn btn-ghost"
                     onClick={() => setReloadKey((k) => k + 1)}
-                    title="Reload"
+                    title={t('chat.reload')}
                 >
                     <svg
                         width="14"
@@ -56,7 +58,7 @@ export function CustomSource() {
                 <button
                     className={styles.vanishBtn}
                     onClick={() => void ToggleVanish()}
-                    title="Vanish"
+                    title={t('chat.vanish')}
                 >
                     <svg
                         width="14"

--- a/frontend/src/components/Home/Home.module.css
+++ b/frontend/src/components/Home/Home.module.css
@@ -60,6 +60,11 @@
     }
 }
 
+.hint {
+    font-size: 11px;
+    color: var(--color-text-dim);
+}
+
 .error {
     width: 100%;
     padding: 8px 12px;

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { useConfigStore } from '@/stores/config';
 import { useConnectionStore } from '@/stores/connection';
+import { isValidSourceURL } from '@/utils/customSource';
 
 import styles from './Home.module.css';
 
@@ -13,10 +14,12 @@ export function Home() {
     const { t } = useTranslation();
     const navigate = useNavigate();
     const config = useConfigStore((s) => s.config);
+    const update = useConfigStore((s) => s.update);
 
     const { connected, inputs, setInput } = useConnectionStore();
     const [error, setError] = useState<string | null>(null);
     const [connecting, setConnecting] = useState<Platform | null>(null);
+    const [sourceURL, setSourceURL] = useState(config?.custom_source?.url ?? '');
 
     const getInput = (platform: Platform): string => {
         if (platform === Platform.PlatformTwitch) {
@@ -31,6 +34,10 @@ export function Home() {
     };
 
     const anyConnected = Object.values(connected).some(Boolean);
+
+    const handleOpenSource = () => {
+        void update({ custom_source: { url: sourceURL } }, { silent: true }).then(() => navigate('/source'));
+    };
 
     const handleToggle = async (platform: Platform) => {
         setError(null);
@@ -160,6 +167,35 @@ export function Home() {
                             : connected[Platform.PlatformKick]
                               ? t('home.disconnect')
                               : t('home.connect')}
+                    </button>
+                </div>
+
+                <div className={styles.card}>
+                    <div className={styles.cardHeader}>
+                        <span className={styles.platformLabel}>
+                            <svg
+                                className={styles.platformIcon}
+                                viewBox="0 0 24 24"
+                                fill="currentColor"
+                            >
+                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+                            </svg>
+                            {t('home.custom_source.label')}
+                        </span>
+                    </div>
+                    <input
+                        type="text"
+                        placeholder={t('home.custom_source.placeholder')}
+                        value={sourceURL}
+                        onChange={(e) => setSourceURL(e.target.value)}
+                    />
+                    <p className={styles.hint}>{t('home.custom_source.hint')}</p>
+                    <button
+                        className="btn btn-primary"
+                        onClick={() => handleOpenSource()}
+                        disabled={!isValidSourceURL(sourceURL)}
+                    >
+                        {t('home.custom_source.open')}
                     </button>
                 </div>
             </div>

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -192,7 +192,7 @@ export function Home() {
                     <p className={styles.hint}>{t('home.custom_source.hint')}</p>
                     <button
                         className="btn btn-primary"
-                        onClick={() => handleOpenSource()}
+                        onClick={handleOpenSource}
                         disabled={!isValidSourceURL(sourceURL)}
                     >
                         {t('home.custom_source.open')}

--- a/frontend/src/utils/customSource.test.ts
+++ b/frontend/src/utils/customSource.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { isValidSourceURL } from './customSource';
+
+describe('isValidSourceURL', () => {
+    describe('accepts valid http/https URLs', () => {
+        it('accepts https with domain', () => {
+            expect(isValidSourceURL('https://example.com')).toBe(true);
+        });
+
+        it('accepts http with localhost and port', () => {
+            expect(isValidSourceURL('http://localhost:8080/overlay')).toBe(true);
+        });
+
+        it('accepts https with query string and fragment', () => {
+            expect(isValidSourceURL('https://x.io/a?token=abc&b=1#frag')).toBe(true);
+        });
+    });
+
+    describe('does not mutate the input string', () => {
+        it('returns a boolean and leaves the input unchanged', () => {
+            const input = 'https://x.io/a?token=abc&b=1#frag';
+            const copy = input;
+            const result = isValidSourceURL(input);
+
+            expect(typeof result).toBe('boolean');
+            expect(input).toBe(copy);
+        });
+    });
+
+    describe('rejects invalid inputs', () => {
+        it('rejects empty string', () => {
+            expect(isValidSourceURL('')).toBe(false);
+        });
+
+        it('rejects whitespace-only string', () => {
+            expect(isValidSourceURL('   ')).toBe(false);
+        });
+
+        it('rejects javascript: scheme', () => {
+            expect(isValidSourceURL('javascript:alert(1)')).toBe(false);
+        });
+
+        it('rejects file: scheme', () => {
+            expect(isValidSourceURL('file:///etc/passwd')).toBe(false);
+        });
+
+        it('rejects data: scheme', () => {
+            expect(isValidSourceURL('data:text/html,x')).toBe(false);
+        });
+
+        it('rejects ftp: scheme', () => {
+            expect(isValidSourceURL('ftp://x')).toBe(false);
+        });
+
+        it('rejects bare domain with no scheme', () => {
+            expect(isValidSourceURL('example.com')).toBe(false);
+        });
+
+        it('rejects relative path', () => {
+            expect(isValidSourceURL('/relative/path')).toBe(false);
+        });
+    });
+});

--- a/frontend/src/utils/customSource.test.ts
+++ b/frontend/src/utils/customSource.test.ts
@@ -18,13 +18,15 @@ describe('isValidSourceURL', () => {
     });
 
     describe('does not mutate the input string', () => {
-        it('returns a boolean and leaves the input unchanged', () => {
+        it('returns stable results across repeated calls with query+fragment', () => {
             const input = 'https://x.io/a?token=abc&b=1#frag';
-            const copy = input;
-            const result = isValidSourceURL(input);
 
-            expect(typeof result).toBe('boolean');
-            expect(input).toBe(copy);
+            const first = isValidSourceURL(input);
+            const second = isValidSourceURL(input);
+
+            expect(first).toBe(true);
+            expect(second).toBe(true);
+            expect(input).toBe('https://x.io/a?token=abc&b=1#frag');
         });
     });
 

--- a/frontend/src/utils/customSource.ts
+++ b/frontend/src/utils/customSource.ts
@@ -1,0 +1,13 @@
+export function isValidSourceURL(input: string): boolean {
+    if (!input || !input.trim()) {
+        return false;
+    }
+
+    try {
+        const parsed = new URL(input);
+
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,15 +83,20 @@ type ThemeConfig struct {
 	CustomThemes  []Theme `json:"custom_themes"`
 }
 
+type CustomSource struct {
+	URL string `json:"url"`
+}
+
 type Config struct {
-	Version     string        `json:"version"`
-	WindowState WindowState   `json:"window_state"`
-	General     General       `json:"general"`
-	Keybinds    Keybinds      `json:"keybinds"`
-	Theme       ThemeConfig   `json:"theme"`
-	Twitch      TwitchConfig  `json:"twitch"`
-	YouTube     YouTubeConfig `json:"youtube"`
-	Kick        KickConfig    `json:"kick"`
+	Version      string        `json:"version"`
+	WindowState  WindowState   `json:"window_state"`
+	General      General       `json:"general"`
+	Keybinds     Keybinds      `json:"keybinds"`
+	Theme        ThemeConfig   `json:"theme"`
+	Twitch       TwitchConfig  `json:"twitch"`
+	YouTube      YouTubeConfig `json:"youtube"`
+	Kick         KickConfig    `json:"kick"`
+	CustomSource CustomSource  `json:"custom_source"`
 }
 
 func DefaultConfig() Config {

--- a/internal/config/custom_source_test.go
+++ b/internal/config/custom_source_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCustomSourceRoundTrip(t *testing.T) {
+	const rawURL = "https://example.com/overlay?token=abc#frag"
+
+	cfg := DefaultConfig()
+	cfg.CustomSource = CustomSource{URL: rawURL}
+
+	data, err := json.Marshal(cfg)
+
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	want := `"custom_source":{"url":"https://example.com/overlay?token=abc#frag"}`
+
+	if !strings.Contains(string(data), want) {
+		t.Errorf("marshaled JSON does not contain %q; got: %s", want, data)
+	}
+
+	var got Config
+
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if got.CustomSource.URL != rawURL {
+		t.Errorf("got URL %q, want %q", got.CustomSource.URL, rawURL)
+	}
+}
+
+func TestCustomSourceBackwardCompat(t *testing.T) {
+	data := []byte(`{"version":"4.0.2","general":{"language":"en-US","show_timestamps":false,"show_waiting_message":true}}`)
+
+	var cfg Config
+
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if cfg.CustomSource.URL != "" {
+		t.Errorf("got URL %q, want empty string", cfg.CustomSource.URL)
+	}
+}

--- a/website/index.html
+++ b/website/index.html
@@ -52,7 +52,7 @@
             <div class="hero-text">
                 <div class="hero-badge">Free and open source</div>
                 <h1>Desktop chat overlay<br>for streamers</h1>
-                <p class="hero-description">Ghost Chat puts your live chat on screen with a transparent, customizable overlay. Supports Twitch, YouTube, and Kick — no login required.</p>
+                <p class="hero-description">Ghost Chat puts your live chat on screen with a transparent, customizable overlay. Supports Twitch, YouTube, and Kick — or render any overlay URL as a custom source. No login required.</p>
                 <div class="hero-actions">
                     <a href="https://github.com/Enubia/ghost-chat/releases" target="_blank" rel="noopener" class="btn btn-primary">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -83,6 +83,13 @@
                     </div>
                     <h3>Multi-platform</h3>
                     <p>Connect to Twitch, YouTube, and Kick simultaneously. Rumble support is on the way.</p>
+                </div>
+                <div class="feature-card reveal">
+                    <div class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>
+                    </div>
+                    <h3>Custom source</h3>
+                    <p>Render any http(s) overlay URL in the chat window instead of a built-in platform. Bring your own chat widget or third-party overlay.</p>
                 </div>
                 <div class="feature-card reveal">
                     <div class="feature-icon">
@@ -186,6 +193,13 @@
                     <summary>What platforms are supported?</summary>
                     <div class="faq-answer">
                         <p>Ghost Chat currently supports Twitch, YouTube, and Kick. Rumble support is in development and will be available in a future update.</p>
+                    </div>
+                </details>
+                <details class="faq-item">
+                    <summary>What is a custom source?</summary>
+                    <div class="faq-answer">
+                        <p>Custom source lets you enter any http(s) URL — such as a third-party chat widget or overlay — and render it in the Ghost Chat window in place of a built-in platform. There is no per-source CSS or JavaScript injection; the URL is displayed as-is inside an iframe.</p>
+                        <p>Note that some sites set headers (X-Frame-Options or Content-Security-Policy) that block embedding. If the page renders blank, the site is preventing iframe embedding and the custom source cannot be used with that URL.</p>
                     </div>
                 </details>
                 <details class="faq-item">


### PR DESCRIPTION
## Summary

Brings back **custom source rendering** (a frequently-requested feature from the old Electron app), reimagined for the Wails v3 stack. A streamer can render their own overlay/chat-widget URL in a full-bleed iframe **instead of** the built-in Twitch/YouTube/Kick chat.

It's a pure-frontend replacement view — it bypasses the Go chat pipeline entirely (no platform connection, websocket, message events, themes, fade, or filters). Out of scope by design: custom CSS/JS injection, multi-URL list, `X-Frame-Options` detection, native-window fallback.

## What's included

- **Config** — additive `CustomSource{ URL string }` (`custom_source.url`), zero-value-safe, no migration; regenerated Wails TS bindings.
- **Home** — a fourth card beside the platform cards: a URL input pre-filled from config and a single **Open overlay** button (no connect/disconnect). The button is gated by `isValidSourceURL` (absolute `http(s)://` only; rejects `javascript:`/`file:`/`data:`/relative). On open it persists the URL via the existing config update path and navigates to `/source`. A helper line notes some sites block embedding.
- **`/source` route + `<CustomSource>`** — minimal header (back / reload / vanish) over a full-bleed iframe. The iframe is intentionally **unsandboxed** (the URL is user-supplied and trusted, like an OBS browser source) and **transparent** so a transparent-bg widget composites over the desktop. Reload remounts via a React `key`; vanish reuses the existing `[data-vanished]` convention; window-level click-through is already handled Go-side.
- **i18n** — keys added to `en-US` and `de-DE` (real German translations), including a new `chat.reload`.
- **Website** — `index.html` hero / features / FAQ document the feature (copy only; screenshots deferred).

Platform connections, the `/` and `/chat` routes, and the Open Chat button are untouched. The app always lands on Home; only the URL persists (no active-mode flag, no auto-navigation).

## Validation

- `go test ./...` — pass
- `pnpm test` — 60 pass (12 new `isValidSourceURL` cases)
- `pnpm build` — 0 errors · `pnpm fix` — clean
- Built test-first; each task spec+quality reviewed, plus a whole-branch correctness review and a maintainability pass — all clean.

Closes #1298
Closes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
